### PR TITLE
async/awaitを利用するようにしました

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,80 +1,66 @@
 'use strict';
 
-const Promise = require('bluebird');
 const phantom = require('phantom');
 const sleep = require('sleep-promise');
 
-module.exports.handler = (event, context, callback) => {
-    return Promise.coroutine(processEvent)(event, context, callback);
-}
-
-function *processEvent(event, context, callback) {
+module.exports.handler = async (event, context, callback) => {
     console.log('lambda is started');
+    let result = null;
     // to quit finally
     let instance;
-
-    Promise.coroutine(function* () {
-        instance = yield phantom.create();
-        const page = yield instance.createPage();
-
-        let status = yield page.open('https://httpbin.org/');
+    instance = await phantom.create();
+    try{
+        const page = await instance.createPage();
+        let status = await page.open('https://httpbin.org/');
         console.log(status);
         if (status != 'success') {
             throw new Error('page is not opend');
         }
 
         /*** page.evaluate return element data to nodejs scope ***/
-        const title = yield page.evaluate(function() {
+        const title = await page.evaluate(function() {
             return document.title;
         });
         console.log(title);
 
-        yield sleep(3000);
+        // wait page has loading
+        await sleep(3000);
 
         /*** you can pass node js variable to evaluating by Template Literals.
         (notice) coulud't pass normal variable. ***/
         let id = 'operations-tag-Request_inspection';
-        const element = yield page.evaluate(function(s) {
-            return document.querySelector('#operations-tag-Request_inspection > small > div > p').innerHTML;
-        }, `#operations-tag-Request_inspection > small > div > p`);
+        const element = await page.evaluate(function(s) {
+            return document.querySelector(s).innerHTML;
+        }, `#${id} > small > div > p`);
         console.log(element);
 
-
         /*** you can post data with form. ***/
-        status = yield page.open('https://httpbin.org/forms/post');
+        status = await page.open('https://httpbin.org/forms/post');
         console.log(status);
         if (status != 'success') {
             throw new Error('page is not opend');
         }
         console.log('input custname "hoge"');
-        yield page.evaluate(function() {
+        await page.evaluate(function() {
             document.forms[0].custname.value = 'hoge';
             document.querySelector('body > form > p:nth-child(8) > button').click();
             // you can also like beloow
             // document.forms[0].submit();
         });
         // wait 2sec
-        yield sleep(2000);
+        await sleep(2000);
         // it can be accessd
-        const custname = yield page.evaluate(function () {
+        const custname = await page.evaluate(function () {
             return JSON.parse(document.querySelector('body > pre').innerHTML).form.custname;
         });
         console.log('your custname:', custname);
 
-
-    })().then(() => {
-        console.log('lambda will ended with success');
-        callback(null, 'done success');
-    }).catch((err) => {
-        console.error(err.stack);
-        console.log('lambda will ended with failure');
-        callback('done failure');
-    }).finally(() => {
-        console.log('finally is started');
-        Promise.coroutine(function *() {
-            yield instance.exit();
-        })().then(() => {
-            console.log('lambda is closed');
-        });
-    });
-};
+    } catch (error) {
+        console.log(error);
+        result = error;
+    } finally {
+        console.log('finally started');
+        await instance.exit();
+    }
+    callback(result);
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/mesh1nek0x0/lambda-ghost#readme",
   "dependencies": {
-    "bluebird": "^3.5.0",
     "node-lambda": "^0.11.3",
     "phantom": "^4.0.5",
     "sleep-promise": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,6 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
-bluebird@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"


### PR DESCRIPTION
## PR内容
掲題の通りです。awsがnode8系でも動くようになったので
bluebirdのPromise.coroutineとgeneratorを利用した書き方から
async/awaitを使った書き方に変更しました

## 変更点
* async/awaitに書き換えてbluebirdを依存関係から削除